### PR TITLE
Step 0 Yay

### DIFF
--- a/src/risktracker.cpp
+++ b/src/risktracker.cpp
@@ -8,6 +8,7 @@ RiskTracker::RiskTracker(float x, std::vector <Trade> trades) : totalRisk(x), pe
 
 int RiskTracker::updateRisk() {
     float runningSum = 0;
+    this->totalRisk = 0;
     for (const auto &x: this->pendingTrades) {
         if (x.side) {
             runningSum += (x.price * x.quantity);

--- a/tst/test_traderisktracker.cpp
+++ b/tst/test_traderisktracker.cpp
@@ -12,9 +12,13 @@ TEST(TradeRiskTrackerTest, TrackerInit) {
     RiskTracker riskTracker(0, trackedTrades);
     EXPECT_EQ(riskTracker.getRisk(), 0);
     riskTracker.updateRisk();
+    riskTracker.updateRisk();
     EXPECT_EQ(riskTracker.getRisk(), 0);
     Trade testTrade3(14, true, 1.55);
     riskTracker.addTrade(testTrade3);
+    riskTracker.updateRisk();
+    riskTracker.updateRisk();
+    EXPECT_NEAR(riskTracker.getRisk(), 21.7, 1e-4);
     riskTracker.updateRisk();
     EXPECT_NEAR(riskTracker.getRisk(), 21.7, 1e-4);
 }


### PR DESCRIPTION
1 What is the purpose of this PR? - Fix the value that totalRisk returns so that it does not count risk multiple times every time updateRisk is called
2 What changes did you make? Why? - Set the value of totalRisk to zero every time updateRisk is called. This change was made so that the values previously present in the vector would not be counted over and over again.
3 What bugs did you find while testing? - The bug I found was the value of totalRisk accounting for the values found in a vector multiple times because it was not set to zero at the beginning of the function call.
(edited)
[11:59](https://northwesternfintechhq.slack.com/archives/D046420SVJA/p1694235592269889)
1 What was the bug you found? - Refer to 3 in first part
2 How did you address it? - Refer to 3 in first part
3 What did you struggle with? - waiting 3 weeks to do it because of my troll timeline
4 Is there anything you would change about this step? - Maybe make more clear whether you actually want the vector to remove values after updateRisk is called or if you want the values to stay and to just reset totalRisk -> I can change the code to my response depending on what the intended answer is